### PR TITLE
Support for UEFI Boot and arm64 architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+target/ami_id.txt

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ This Ansible role comes with the following requirements:
    * An AWS Account where to execute the creation of the AMI
    * An access key pair with enough privileges to execute ec2 and cloudformation
      operations
-   * Permission to launch an official RockyLinux v9 AMI from the AWS Marketplace
-     The best thing to do is to manually create a t2.nano instance and to
-     destroy it immediately as this process will ask for the permission to
+   * Permission to launch an official Rocky Linux v9 AMI from the AWS Marketplace
+     The best thing to do is to manually create a t3.micro to t4g.micro instance
+     and to destroy it immediately as this process will ask for the permission to
      launch such instances in your AWS Account:
      https://aws.amazon.com/marketplace/pp/prodview-ygp66mwgbl2ii
 
 ## How it works
 This Ansible role works by first using Cloud Formations to create a temporary
 stack in your AWS Account which contains a VPC and an EC2 instance. This
-instance is running an official RockyLinux image and the new RockyLinux
+instance is running an official Rocky Linux image and the new Rocky Linux
 operating system will be installed on a secondary empty EBS volume. At the end
 of the installation the instance is stopped and the new AMI is created as an
 image of the secondary volume. The stack and all its resources are destroyed
@@ -45,7 +45,28 @@ and only the new AMI and its corresponding EBS snapshot remain.
 ## How to use it
    * Install this role using ansible-galaxy
      https://galaxy.ansible.com/fdupoux/rockylinux_ami_builder
-   * Manually create an EC2 t2.micro instance from an official RockyLinux AMI to
+   * Manually create an EC2 an instance from an official Rocky Linux AMI to
      authorize the use of these AMI in your AWS account
    * Use this role from an ansible playbook and make sure you pass all the
-     important parameters which are defined in the defaults/main.yml file
+     important parameters which are defined in the defaults/main.yml file.
+     Please have a look at the example playbook provided in the docs folder
+     for examples of parameters that can be used for x86_64 and arm64.
+
+## Features
+This Ansible role can produce Rocky Linux v9 AMI for both x86_64 and arm64.
+These AMI can be used with modern instance types such as t3/t3a and t4g.
+The AMI is configured to have both IPv4 and IPv6 enabled. On x86_64
+it boots the system in Legacy BIOS mode, and on arm64 it boots in UEFI mode,
+as these are the default boot modes with AWS for these two architectures.
+
+## Testing
+This role has been tested using Ansible 2.10.7 as provided with Debian 11
+which is not very recent, hence it does not require a very recent version
+of Ansible for this to work. It should naturally also work with more recent
+versions of Ansible.
+
+The creation of an AMI for x86_64 has been tested using a "t3.small" instance,
+and an AMI for arm64 has been created using a "t4g.small" instance. These two
+instance types come with modern features and are affordable. This should also
+work on other modern instance types, but may not work with older instance
+types such as t1 and t2.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,8 @@ rockylinux_ami_builder_vgname: "vgmain"
 rockylinux_ami_builder_disksize: '8'
 rockylinux_ami_builder_disktype: 'gp2'
 rockylinux_ami_builder_rootsize: '4096M'
-rockylinux_ami_builder_bootsize: '512M'
 rockylinux_ami_builder_username: 'rocky'
+rockylinux_ami_builder_architecture: 'x86_64'
 
 # EC2 instance type of the temporary instance used to build the new AMI
 rockylinux_ami_builder_ec2_type: "t3.small"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ rockylinux_ami_builder_disksize: '8'
 rockylinux_ami_builder_disktype: 'gp2'
 rockylinux_ami_builder_rootsize: '4096M'
 rockylinux_ami_builder_username: 'rocky'
+
+# Architecture for which to build the AMI (must be either 'x86_64' or 'arm64')
 rockylinux_ami_builder_architecture: 'x86_64'
 
 # EC2 instance type of the temporary instance used to build the new AMI
@@ -32,5 +34,11 @@ rockylinux_ami_builder_disk2mnt: '/mnt/root'
 rockylinux_ami_builder_stack_name: 'stack-ami-builder'
 rockylinux_ami_builder_stack_cidrbase: '10.89'
 
+# Architectures mappings
+rockylinux_ami_builder_arch1dict: {"x86_64":"x86_64", "arm64":"aarch64"}
+rockylinux_ami_builder_arch2dict: {"x86_64":"amd64", "arm64":"arm64"}
+rockylinux_ami_builder_rpmarch: "{{ rockylinux_ami_builder_arch1dict[rockylinux_ami_builder_architecture] }}"
+rockylinux_ami_builder_tplarch: "{{ rockylinux_ami_builder_arch2dict[rockylinux_ami_builder_architecture] }}"
+
 # Address of the package repository
-rockylinux_ami_builder_baseurl: "https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/Packages"
+rockylinux_ami_builder_baseurl: "https://download.rockylinux.org/pub/rocky/9/BaseOS/{{ rockylinux_ami_builder_rpmarch }}/os/Packages"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ rockylinux_ami_builder_aws_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
 rockylinux_ami_builder_ec2_keypair: ""
 rockylinux_ami_builder_vgname: "vgmain"
 rockylinux_ami_builder_disksize: '8'
-rockylinux_ami_builder_disktype: 'gp2'
+rockylinux_ami_builder_disktype: 'gp3'
 rockylinux_ami_builder_rootsize: '4096M'
 rockylinux_ami_builder_username: 'rocky'
 

--- a/docs/playbook-rockylinux-ami-creator.yml
+++ b/docs/playbook-rockylinux-ami-creator.yml
@@ -1,16 +1,31 @@
 ---
-- name: Example to show how to create a custom Rocky-Linux v9 AMI
+- name: Example to show how to create a custom Rocky-Linux v9 AMI for amd64
   hosts: localhost
 
   roles:
-    - role: rockylinux-ami-builder
+    - role: rockylinux-ami-builder-amd64
       rockylinux_ami_builder_aws_region: "eu-west-1"
       rockylinux_ami_builder_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
       rockylinux_ami_builder_aws_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
-      rockylinux_ami_builder_ec2_keypair: "francois@home"
-      rockylinux_ami_builder_username: 'rockylinux'
+      rockylinux_ami_builder_ec2_keypair: "francois"
+      rockylinux_ami_builder_username: 'rocky'
       rockylinux_ami_builder_vgname: "vgmain"
       rockylinux_ami_builder_disksize: '8'
-      rockylinux_ami_builder_bootsize: '256M'
       rockylinux_ami_builder_rootsize: '4096M'
       rockylinux_ami_builder_allowip: '0.0.0.0/0'
+      rockylinux_ami_builder_ami_name: "ami_rockylinux9_amd64"
+      rockylinux_ami_builder_architecture: 'x86_64'
+      rockylinux_ami_builder_ec2_type: "t3.small"
+    - role: rockylinux-ami-builder-arm64
+      rockylinux_ami_builder_aws_region: "eu-west-1"
+      rockylinux_ami_builder_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      rockylinux_ami_builder_aws_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      rockylinux_ami_builder_ec2_keypair: "francois"
+      rockylinux_ami_builder_username: 'rocky'
+      rockylinux_ami_builder_vgname: "vgmain"
+      rockylinux_ami_builder_disksize: '8'
+      rockylinux_ami_builder_rootsize: '4096M'
+      rockylinux_ami_builder_allowip: '0.0.0.0/0'
+      rockylinux_ami_builder_ami_name: "ami_rockylinux9_arm64"
+      rockylinux_ami_builder_architecture: 'arm64'
+      rockylinux_ami_builder_ec2_type: "t4g.small"

--- a/files/temp-vpc-with-temp-ec2.json
+++ b/files/temp-vpc-with-temp-ec2.json
@@ -14,13 +14,20 @@
       "Description" : "Temporary EC2 instance type",
       "Type" : "String",
       "Default" : "t3.small",
-      "AllowedValues" : ["t3.micro", "t3.small", "t3.medium", "t3.large", "t3.xlarge"],
-      "ConstraintDescription" : "Must be a supported t3 ec2 instance type."
+      "AllowedValues" : ["t3.micro", "t3.small", "t3.medium", "t3.large", "t4g.micro", "t4g.small", "t4g.medium", "t4g.large"],
+      "ConstraintDescription" : "Must be a supported t3 or t4g instance type."
     },
 
     "AwsRegion": {
       "Description" : "Region where to create the resources",
       "Type" : "String"
+    },
+
+    "Architecture": {
+      "Description" : "Architecture of the AMI to build (either 'amd64' or 'arm64')",
+      "Type" : "String",
+      "Default" : "amd64",
+      "AllowedValues" : ["amd64", "arm64"]
     },
 
     "KeyName": {
@@ -58,29 +65,24 @@
 
   "Mappings" : {
     "AwsRegion2RockyLinuxAmi" : {
-      "us-east-1"        : {"RockyLinuxAmi" : "ami-0cce0fd28f5ae1c16"},
-      "us-east-2"        : {"RockyLinuxAmi" : "ami-013b70fe77d288975"},
-      "us-west-1"        : {"RockyLinuxAmi" : "ami-0565bb3165a897d89"},
-      "us-west-2"        : {"RockyLinuxAmi" : "ami-003100cf7f2c7c335"},
-      "af-south-1"       : {"RockyLinuxAmi" : "ami-0a80a99c381015ebc"},
-      "ap-east-1"        : {"RockyLinuxAmi" : "ami-07511107f64b24069"},
-      "ap-south-1"       : {"RockyLinuxAmi" : "ami-0513a35b6dde0be00"},
-      "ap-northeast-1"   : {"RockyLinuxAmi" : "ami-054929b521ab4b542"},
-      "ap-northeast-2"   : {"RockyLinuxAmi" : "ami-0181531710ee41148"},
-      "ap-northeast-3"   : {"RockyLinuxAmi" : "ami-0f2f53e190dc1dc4f"},
-      "ap-southeast-1"   : {"RockyLinuxAmi" : "ami-0255a102dbb96cef7"},
-      "ap-southeast-2"   : {"RockyLinuxAmi" : "ami-02da9facaa1d0b6bd"},
-      "ap-southeast-3"   : {"RockyLinuxAmi" : "ami-041f2e1830aaef14c"},
-      "ca-central-1"     : {"RockyLinuxAmi" : "ami-0b348d5e264c7d410"},
-      "eu-central-1"     : {"RockyLinuxAmi" : "ami-0414d15e93b201470"},
-      "eu-west-1"        : {"RockyLinuxAmi" : "ami-0da0f91219b2ab4c1"},
-      "eu-west-2"        : {"RockyLinuxAmi" : "ami-04fe632f7f0954fe7"},
-      "eu-west-3"        : {"RockyLinuxAmi" : "ami-06ca0d6ccc3e7a5ce"},
-      "eu-south-1"       : {"RockyLinuxAmi" : "ami-040aa80fac5b3330c"},
-      "eu-north-1"       : {"RockyLinuxAmi" : "ami-06c1cb612a06c3cff"},
-      "me-central-1"     : {"RockyLinuxAmi" : "ami-0817a73ca1752acd5"},
-      "me-south-1"       : {"RockyLinuxAmi" : "ami-013dbdc0a3e6b4c39"},
-      "sa-east-1"        : {"RockyLinuxAmi" : "ami-0ec9d7ece5f35188c"}
+      "us-east-1"        : {"amd64" : "ami-0cce0fd28f5ae1c16", "arm64" : "ami-00b0dcadee599a758"},
+      "us-east-2"        : {"amd64" : "ami-013b70fe77d288975", "arm64" : "ami-0a4ca78b119e1b2c4"},
+      "us-west-1"        : {"amd64" : "ami-0565bb3165a897d89", "arm64" : "ami-0613fcbcf8ac10955"},
+      "us-west-2"        : {"amd64" : "ami-0c6ad0cb888dc015a", "arm64" : "ami-0d591df4a537c24fc"},
+      "ap-south-1"       : {"amd64" : "ami-0513a35b6dde0be00", "arm64" : "ami-0cb24451efb0e807e"},
+      "ap-northeast-1"   : {"amd64" : "ami-054929b521ab4b542", "arm64" : "ami-01aa25ac6fa78cce1"},
+      "ap-northeast-2"   : {"amd64" : "ami-0181531710ee41148", "arm64" : "ami-02d35205aa1a0f6c9"},
+      "ap-northeast-3"   : {"amd64" : "ami-0f2f53e190dc1dc4f", "arm64" : "ami-0bcb5f23007ad2985"},
+      "ap-southeast-1"   : {"amd64" : "ami-0255a102dbb96cef7", "arm64" : "ami-0c7c89825e02c8db1"},
+      "ap-southeast-2"   : {"amd64" : "ami-02da9facaa1d0b6bd", "arm64" : "ami-036af2e62fdf543b9"},
+      "eu-central-1"     : {"amd64" : "ami-0414d15e93b201470", "arm64" : "ami-0ae0e088f1170391d"},
+      "eu-west-1"        : {"amd64" : "ami-06cce7b9e26e82474", "arm64" : "ami-0ba529caebf80385d"},
+      "eu-west-2"        : {"amd64" : "ami-04fe632f7f0954fe7", "arm64" : "ami-0723dd316a68a3ec8"},
+      "eu-west-3"        : {"amd64" : "ami-06ca0d6ccc3e7a5ce", "arm64" : "ami-000d7efc6c601dba8"},
+      "eu-north-1"       : {"amd64" : "ami-06c1cb612a06c3cff", "arm64" : "ami-0ef3b1b9aca44893b"},
+      "me-central-1"     : {"amd64" : "ami-0817a73ca1752acd5", "arm64" : "ami-0e6ec5db88f73d607"},
+      "me-south-1"       : {"amd64" : "ami-013dbdc0a3e6b4c39", "arm64" : "ami-03f1a5113ed8b2dd7"},
+      "sa-east-1"        : {"amd64" : "ami-0ec9d7ece5f35188c", "arm64" : "ami-0fe18ca139b0b5dde"}
     }
   },
 
@@ -168,7 +170,7 @@
       "Type" : "AWS::EC2::Instance",
       "DependsOn" : "AttachGateway",
       "Properties" : {
-        "ImageId" : { "Fn::FindInMap" : [ "AwsRegion2RockyLinuxAmi", { "Ref" : "AwsRegion" }, "RockyLinuxAmi"] },
+        "ImageId" : { "Fn::FindInMap" : [ "AwsRegion2RockyLinuxAmi", { "Ref" : "AwsRegion" }, { "Ref" : "Architecture" }] },
         "InstanceType" : { "Ref" : "InstanceType" },
         "KeyName" : { "Ref" : "KeyName" },
         "SubnetId" : { "Ref" : "Subnet" },

--- a/files/temp-vpc-with-temp-ec2.json
+++ b/files/temp-vpc-with-temp-ec2.json
@@ -183,7 +183,7 @@
       "Type" : "AWS::EC2::Volume",
       "Properties" : {
         "Size" : { "Ref" : "DiskSizeGb" },
-        "VolumeType" : "gp2",
+        "VolumeType" : "gp3",
         "AvailabilityZone" : { "Fn::GetAtt" : [ "AmiBuilderInstance", "AvailabilityZone" ] }
       },
       "DeletionPolicy" : "Delete"

--- a/tasks/01_create.yml
+++ b/tasks/01_create.yml
@@ -10,6 +10,7 @@
     template_parameters:
       StackName: "{{ rockylinux_ami_builder_stack_name }}"
       InstanceType: "{{ rockylinux_ami_builder_ec2_type }}"
+      Architecture: "{{ rockylinux_ami_builder_tplarch }}"
       AwsRegion: "{{ rockylinux_ami_builder_aws_region }}"
       DiskDevice: "{{ rockylinux_ami_builder_disk2name }}"
       DiskSizeGb: "{{ rockylinux_ami_builder_disksize }}"

--- a/tasks/02_install.yml
+++ b/tasks/02_install.yml
@@ -184,13 +184,14 @@
     - etc/fstab
 
 - name: Install kernel and grub packages
-  shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /bin/dnf -y install kernel kernel-devel grub2 grubby grub2-efi grub2-tools efibootmgr
+  shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /bin/dnf -y install kernel kernel-devel grub2 grubby grub2-efi grub2-tools shim efibootmgr
 
 - name: Generate grub2 configuration file
   shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
 
-- name: Execute grub2 installer
+- name: Execute grub2 installer (for Legacy BIOS only)
   shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /sbin/grub2-install {{ rockylinux_ami_builder_disk2dev }}
+  when: rockylinux_ami_builder_architecture == 'x86_64'
 
 - name: Clean installation packages
   shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /bin/dnf clean all

--- a/tasks/02_install.yml
+++ b/tasks/02_install.yml
@@ -38,8 +38,11 @@
 
 - name: Install system package
   package:
-    name: ['parted', 'lvm2']
+    name: ['parted', 'lvm2', 'dosfstools']
     state: installed
+
+- name: Stop grub from finding the system on the primary disk
+  shell: rm -f /etc/{os,redhat,rocky}-release*
 
 - name: Create mount point for chroot environment
   file:
@@ -53,28 +56,43 @@
   shell: ls -lh {{ rockylinux_ami_builder_disk2dev }}
 
 - name: Create new partition table on the second EBS Volume
-  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mklabel msdos
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mklabel gpt
+
+- name: Create efi partition on the new disk
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mkpart uefi fat32 1MB 255M
+
+- name: Create bios partition on the new disk
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mkpart bios fat16 255M 256M
 
 - name: Create boot partition on the new disk
-  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mkpart primary ext4 1MB {{ rockylinux_ami_builder_bootsize }}
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mkpart boot ext4 256M 1024M
 
 - name: Create lvm partition on the new disk
-  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mkpart primary ext4 {{ rockylinux_ami_builder_bootsize }} 100%
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} mkpart lvm2 ext4 1024M 100%
 
-- name: Set partition flags on boot
-  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} set 1 boot on
+- name: Set partition flags on the efi system partition
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} set 1 esp on
 
-- name: Set partition flags on lvm
-  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} set 2 lvm on
+- name: Set partition flags on the bios partition
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} set 2 bios_grub on
+
+- name: Set partition flags on the lvm partition
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} set 4 lvm on
+
+- name: Print new disk layout
+  shell: parted --script {{ rockylinux_ami_builder_disk2dev }} print
+
+- name: Create efi-esp filesystem
+  shell: mkfs.fat -F 32 -n esp {{ rockylinux_ami_builder_disk2dev }}p1
 
 - name: Create boot filesystem
-  shell: mkfs.ext4 -L boot {{ rockylinux_ami_builder_disk2dev }}p1
+  shell: mkfs.ext4 -L boot {{ rockylinux_ami_builder_disk2dev }}p3
 
 - name: Create LVM Physical-Volume
-  shell: pvcreate -ff --yes {{ rockylinux_ami_builder_disk2dev }}p2
+  shell: pvcreate -ff --yes {{ rockylinux_ami_builder_disk2dev }}p4
 
 - name: Create LVM Volume-Group
-  shell: vgcreate {{ rockylinux_ami_builder_vgname }} {{ rockylinux_ami_builder_disk2dev }}p2
+  shell: vgcreate {{ rockylinux_ami_builder_vgname }} {{ rockylinux_ami_builder_disk2dev }}p4
 
 - name: Create LVM Logical-Volume
   shell: lvcreate --yes --wipesignatures=y --zero=y --name=root --size={{ rockylinux_ami_builder_rootsize }} {{ rockylinux_ami_builder_vgname }}
@@ -93,7 +111,17 @@
     warn: false
 
 - name: Mount boot filesystem
-  shell: mount /dev/disk/by-label/boot {{ rockylinux_ami_builder_disk2mnt }}/boot
+  shell: mount {{ rockylinux_ami_builder_disk2dev }}p3 {{ rockylinux_ami_builder_disk2mnt }}/boot
+  args:
+    warn: false
+
+- name: Create mount point for the esp filesystem
+  shell: mkdir -p {{ rockylinux_ami_builder_disk2mnt }}/boot/efi
+  args:
+    warn: false
+
+- name: Mount esp filesystem
+  shell: mount {{ rockylinux_ami_builder_disk2dev }}p1 {{ rockylinux_ami_builder_disk2mnt }}/boot/efi
   args:
     warn: false
 
@@ -156,7 +184,7 @@
     - etc/fstab
 
 - name: Install kernel and grub packages
-  shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /bin/dnf -y install kernel kernel-devel grub2 grubby grub2-tools
+  shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /bin/dnf -y install kernel kernel-devel grub2 grubby grub2-efi grub2-tools efibootmgr
 
 - name: Generate grub2 configuration file
   shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
@@ -169,7 +197,7 @@
 
 - name: Unmount chroot environment mounts
   shell: umount {{ rockylinux_ami_builder_disk2mnt }}/{{ item }}
-  with_items: ['proc', 'dev', 'sys', 'boot']
+  with_items: ['boot/efi', 'boot', 'proc', 'dev', 'sys']
 
 - name: Unmount chroot environment root
   shell: umount {{ rockylinux_ami_builder_disk2mnt }}

--- a/tasks/02_install.yml
+++ b/tasks/02_install.yml
@@ -196,6 +196,9 @@
 - name: Clean installation packages
   shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /bin/dnf clean all
 
+- name: Disable the kdump service
+  shell: chroot {{ rockylinux_ami_builder_disk2mnt }} /bin/systemctl disable kdump
+
 - name: Unmount chroot environment mounts
   shell: umount {{ rockylinux_ami_builder_disk2mnt }}/{{ item }}
   with_items: ['boot/efi', 'boot', 'proc', 'dev', 'sys']

--- a/tasks/03_image.yml
+++ b/tasks/03_image.yml
@@ -40,7 +40,7 @@
     region: "{{ rockylinux_ami_builder_aws_region }}"
     name: "{{ rockylinux_ami_builder_ami_fullname }}"
     state: present
-    architecture: x86_64
+    architecture: "{{ rockylinux_ami_builder_architecture }}"
     virtualization_type: hvm
     enhanced_networking: true
     root_device_name: "/dev/sda1"

--- a/templates/etc/cloud/cloud.cfg.j2
+++ b/templates/etc/cloud/cloud.cfg.j2
@@ -99,5 +99,5 @@ system_info:
    ssh_svcname: sshd
 
 runcmd:
- - growpart /dev/nvme0n1 2
- - pvresize /dev/nvme0n1p2
+ - growpart /dev/nvme0n1 4
+ - pvresize /dev/nvme0n1p4

--- a/templates/etc/fstab.j2
+++ b/templates/etc/fstab.j2
@@ -1,2 +1,3 @@
-LABEL=boot      /boot        ext4    defaults        1       1
 LABEL=root      /            ext4    defaults        1       1
+LABEL=boot      /boot        ext4    defaults        1       1
+LABEL=esp       /boot/efi    vfat    defaults        1       1


### PR DESCRIPTION
- Use a GPT partition table and create an ESP (EFI System Partition) to add support for UEFI Boot
- Add support for the arm64 architecture which is supported by Rocky Linux as "aarch64"
- Support for recent instance types such as T3, T3a, T4g and tested the build process and AMI on T3 and T4g
- Updated the documentation to explain how to build the AMI for either amd64 or arm64